### PR TITLE
Limit simulation horizon for correct coalescence output

### DIFF
--- a/src/main/java/pedigree/Simulator.java
+++ b/src/main/java/pedigree/Simulator.java
@@ -2,6 +2,7 @@ package pedigree;
 
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
@@ -22,6 +23,10 @@ public class Simulator {
     private final double fidelity;
     private final double span;
     private final double reproductionRate;
+    private final double horizon;
+
+    private double nextSample;
+    private final List<PointPop> popSamples;
 
     private static final double DEFAULT_FIDELITY = 0.1;
     private static final double DEFAULT_STABLE_RATE = 2.2;
@@ -39,7 +44,7 @@ public class Simulator {
             return Double.compare(o1.getBirthTime(),o2.getBirthTime());
         }
     }
-    public Simulator() {
+    public Simulator(long seed, double horizon) {
         events = new PriorityQueue<>(new EventComparator());
         males = new PriorityQueue<>(new PopComparator());
         availableMales = new TreeSet<>(new PopComparator());
@@ -47,9 +52,20 @@ public class Simulator {
         model = new AgeModel();
         span = model.expectedParenthoodSpan(Sim.MIN_MATING_AGE_F, Sim.MAX_MATING_AGE_F);
         fidelity = DEFAULT_FIDELITY;
-        reproductionRate = DEFAULT_STABLE_RATE/span;
-        rnd = new Random();
+        reproductionRate = DEFAULT_STABLE_RATE / span;
+        rnd = new Random(seed);
         calendarTime = 0.0; // Starting Time
+        this.horizon = horizon;
+        nextSample = 0.0;
+        popSamples = new ArrayList<>();
+    }
+
+    public Simulator(long seed) {
+        this(seed, 0.0);
+    }
+
+    public Simulator() {
+        this(System.currentTimeMillis(), 0.0);
     }
 
     public double getTime(){
@@ -65,6 +81,9 @@ public class Simulator {
     }
 
     public enum Events {Birth, Death, Reproduction, EntersMatingAge, ExitsMatingAge};
+
+    /** Point de suivi de la population vivante. */
+    public record PointPop(double time, int pop) {}
 
 
 
@@ -114,6 +133,11 @@ public class Simulator {
         return !events.isEmpty();
     }
 
+    /** Ajoute un événement de naissance sans exécution immédiate. */
+    public void scheduleBirthEvent(Sim sim) {
+        events.add(new Event(Events.Birth, sim, sim.getBirthTime()));
+    }
+
 
 
 
@@ -132,6 +156,7 @@ public class Simulator {
         double death = founder.getBirthTime() + model.randomAge(rnd);
         founder.setDeath(death);
         events.add(new Event(Events.Death, founder, founder.getDeathTime()));
+        samplePopulation();
     }
 
     public void Birth(Sim mother, Sim father){
@@ -150,6 +175,7 @@ public class Simulator {
         double death = child.getBirthTime() + model.randomAge(rnd);
         child.setDeath(death);
         events.add(new Event(Events.Death, child, child.getDeathTime()));
+        samplePopulation();
     }
 
 
@@ -164,6 +190,7 @@ public class Simulator {
         else {
             males.remove(s);
         }
+        samplePopulation();
     }
 
 
@@ -227,6 +254,32 @@ public class Simulator {
         if (nextTime > 0 && nextTime < mother.getDeathTime() &&
                 calendarTime - mother.getBirthTime() < Sim.MAX_MATING_AGE_F) {
             events.add(new Event(Events.Reproduction, mother, nextTime));
+        }
+        samplePopulation();
+    }
+
+    /** Renvoie la population vivante à l'instant courant. */
+    public Collection<Sim> getLivingPopulation() {
+        List<Sim> pop = new ArrayList<>(males);
+        pop.addAll(females);
+        return pop;
+    }
+
+    /** Échantillons de population tous les 100 ans. */
+    public List<PointPop> getPopSamples() {
+        return popSamples;
+    }
+
+    /** Force l'enregistrement d'un échantillon à l'instant courant. */
+    public void recordSample() {
+        samplePopulation();
+    }
+
+    /** Met à jour la liste de points si l'on a passé le prochain jalon. */
+    private void samplePopulation() {
+        while (calendarTime >= nextSample && nextSample <= horizon) {
+            popSamples.add(new PointPop(nextSample, getPopulation()));
+            nextSample += 100.0;
         }
     }
 }


### PR DESCRIPTION
## Summary
- stop event loop once the present (time 0) is reached
- expose `recordSample()` in `Simulator` to force a population sample at the end
- start coalescence timeline at 0 so times grow into the past

## Testing
- `javac src/main/java/pedigree/*.java -d /tmp/test-build`
- `javac -cp /tmp/test-build src/main/java/pedigree/Coalescence.java -d /tmp/test-build`
- `javac -cp /tmp/test-build:$(pwd)/lib/junit-4.13.2.jar src/test/java/pedigree/*.java -d /tmp/test-build` *(fails: package org.junit.jupiter.api does not exist)*


------
https://chatgpt.com/codex/tasks/task_e_686c663fa8f48325abfe6f839ae0e340