### PR TITLE
Fix getLivingPopulation with PriorityQueueO

### DIFF
--- a/src/main/java/pedigree/PriorityQueueO.java
+++ b/src/main/java/pedigree/PriorityQueueO.java
@@ -3,6 +3,7 @@ package pedigree;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -129,5 +130,16 @@ public class PriorityQueueO<T> {
         T tmp = heap.get(i);
         heap.set(i, heap.get(j));
         heap.set(j, tmp);
+    }
+
+    /**
+     * Returns a snapshot of the elements currently stored in this queue.
+     * The returned list is independent from the internal heap and
+     * modifications on either side will not affect the other.
+     *
+     * @return copy of the queue's contents in arbitrary order
+     */
+    public List<T> toList() {
+        return new ArrayList<>(heap);
     }
 }

--- a/src/main/java/pedigree/Simulator.java
+++ b/src/main/java/pedigree/Simulator.java
@@ -260,8 +260,9 @@ public class Simulator {
 
     /** Renvoie la population vivante à l'instant courant. */
     public Collection<Sim> getLivingPopulation() {
-        List<Sim> pop = new ArrayList<>(males);
-        pop.addAll(females);
+        List<Sim> pop = new ArrayList<>(males.size() + females.size());
+        pop.addAll(males.toList());
+        pop.addAll(females.toList());
         return pop;
     }
 


### PR DESCRIPTION
## Summary
- add `toList` helper to `PriorityQueueO`
- adapt `Simulator.getLivingPopulation` to use the helper

## Testing
- `javac -d target/classes $(find src/main/java -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_e_686c8e18ca6083259325d7ac7b9e7b57